### PR TITLE
13-alstn113

### DIFF
--- a/alstn113/DFS/13-여행경로.py
+++ b/alstn113/DFS/13-여행경로.py
@@ -1,0 +1,28 @@
+# https://school.programmers.co.kr/learn/courses/30/lessons/43164
+# 여행경로
+
+def solution(tickets):
+    answer = []
+    visited = [False]*len(tickets)
+
+    def dfs(current, path):
+        # 노드들(path)의 개수 = 간선들(tickets)의 개수 + 1
+        if len(path) == len(tickets)+1:
+            answer.append(path)
+            return
+
+        for idx, ticket in enumerate(tickets):
+            if visited[idx]:
+                continue
+
+            a, b = ticket
+            if current == a:
+                visited[idx] = True
+                dfs(b, path + [b])
+                visited[idx] = False
+
+    dfs("ICN", ["ICN"])
+    answer.sort()
+
+    return answer[0]
+

--- a/alstn113/README.md
+++ b/alstn113/README.md
@@ -13,6 +13,7 @@
 | 9차시  | 2023.11.15 |   누적합   |              [태상이의 훈련소 생활](https://www.acmicpc.net/problem/19951)               | [#27](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/27) |
 | 10차시 | 2023.11.17 | 다익스트라 |              [특정 거리의 도시 찾기](https://www.acmicpc.net/problem/18352)              | [#27](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/28) |
 | 11차시 | 2023.11.20 |    DFS     |       [양과 늑대](https://school.programmers.co.kr/learn/courses/30/lessons/92343)       | [#32](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/32) |
-| 12차시 | 2023.11.22 |    Heap    |       [야근 지수](https://school.programmers.co.kr/learn/courses/30/lessons/12927)       | [#36](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/32) |
+| 12차시 | 2023.11.22 |    Heap    |       [야근 지수](https://school.programmers.co.kr/learn/courses/30/lessons/12927)       | [#36](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/36) |
+| 13차시 | 2023.11.23 |    DFS     |       [여행경로](https://school.programmers.co.kr/learn/courses/30/lessons/43164)        | [#39](https://github.com/AlgoLeadMe/AlgoLeadMe-2/pull/39) |
 
 ---


### PR DESCRIPTION
## 🔗 문제 링크

[여행경로](https://school.programmers.co.kr/learn/courses/30/lessons/43164)

## ✔️ 소요된 시간

1시간

## ✨ 수도 코드

**문제 설명은 다음과 같다.**

a->b로 가는 항공권(tickets) 배열을 받는다. ex) [["ICN", "JFK"], ["HND", "IAD"], ["JFK", "HND"]]
주어진 항공권을 모두 사용해야하고, 모든 도시를 방문할 수 없는 경우는 주어지지 않는다.

가능한 경로가 여러개일 경우 알파벳순으로 빠른 것을 리턴한다.
예를 들어, 
["ICN", "SFO", "ATL", "ICN", "ATL", "SFO"] 순으로 방문할 수도 있지만 
["ICN", "ATL", "ICN", "SFO", "ATL", "SFO"] 가 알파벳 순으로 앞선다.

**본격적인 풀이로 가보겠습니다.**
우선 dfs로 바로 생각을 했습니다. 근데 보통은 노드를 방문에 대한 문제가 많아서 생각하는데 오래 걸렸습니다.
이 문제는 간선에 대해 방문하는 문제입니다. 그래서 간선에 대한 visited를 만들었습니다.
그리고 아래의 코드와 같이 모든 해당 간선을 방문합니다. 그리고 방문한 간선은 체크하고 재방문하지 않습니다.

```py
  visited[idx] = True
  dfs(b, path + [b])
  visited[idx] = False
```
 if len(path) == len(tickets)+1: 의 의미는 모든 항공권을 다 사용했다는 의미이므로 
해당하는 경로를 answer 배열에 넣습니다.
그리고 마지막에 answer를 정렬해 사전순으로 제일 빠른 배열을 리턴합니다.

--- 

문제를 푼 후 좀 찾아보니, dfs를 돌면서 정답 배열에 들어간 것보다 사전순으로 뒤에 있으면 조기 종료시키는 방법이 있었습니다.
그 코드를 적용하면 302.35ms -> 10.52ms로 줄일 수 있었습니다.


<details>
<summary><h3>제가 푼 풀이 - python</h3></summary>

```py
def solution(tickets):
    answer = []
    visited = [False]*len(tickets)

    def dfs(current, path):
        # 노드들(path)의 개수 = 간선들(tickets)의 개수 + 1
        if len(path) == len(tickets)+1:
            answer.append(path)
            return

        for idx, ticket in enumerate(tickets):
            if visited[idx]:
                continue

            a, b = ticket
            if current == a:
                visited[idx] = True
                dfs(b, path + [b])
                visited[idx] = False

    dfs("ICN", ["ICN"])
    answer.sort()

    return answer[0]


```

</details>

## 📚 새롭게 알게된 내용

